### PR TITLE
Add the childrenOf query filter for search results to the allowed filters.

### DIFF
--- a/ebi/ols/api/base.py
+++ b/ebi/ols/api/base.py
@@ -114,16 +114,16 @@ class BaseClient:
             {'exact', 'fieldList', 'groupField', 'obsoletes', 'ontology', 'queryFields', 'slim', 'type', 'local', 'childrenOf'}), \
             "Unauthorized filter key"
         if 'childrenOf' in filters:
-            if type(filters['childrenOf']) is str:
+            if isinstance(filters['childrenOf'], str):
                 assertion_set = set(filters['childrenOf'].split(','))
-            elif type(filters['childrenOf']) is set:
+            elif isinstance(filters['childrenOf'], set):
                 assertion_set = filters['childrenOf']
             else:
                 raise AssertionError("Wrong filter childrenOf %s" % filters['childrenOf'])
         if 'fieldList' in filters:
-            if type(filters['fieldList']) is str:
+            if isinstance(filters['fieldList'], str):
                 assertion_set = set(filters['fieldList'].split(','))
-            elif type(filters['fieldList']) is set:
+            elif isinstance(filters['fieldList'],set):
                 assertion_set = filters['fieldList']
             else:
                 raise AssertionError("Wrong filter FieldList %s" % filters['fieldList'])
@@ -132,9 +132,9 @@ class BaseClient:
                  'ontology_prefix', 'short_form', 'type'}
             ), "Wrong fieldList - check OLS doc"
         if 'queryFields' in filters:
-            if type(filters['queryFields']) is str:
+            if isinstance(filters['queryFields'], str):
                 assertion_set = set(filters['queryFields'].split(','))
-            elif type(filters['queryFields']) is set:
+            elif isinstance(filters['queryFields'], set):
                 assertion_set = filters['queryFields']
             else:
                 raise AssertionError("Wrong filter queryFields %s" % filters['queryFields'])
@@ -142,9 +142,9 @@ class BaseClient:
                 {'annotations', 'description', 'iri', 'label', 'logical_description', 'obo_id', 'short_form', 'synonym'}
             ), "Wrong queryFields - check OLS doc"
         if 'type' in filters:
-            if type(filters['type']) is str:
+            if isinstance(filters['type'], str):
                 assertion_set = set(filters['type'].split(','))
-            elif type(filters['type']) is set:
+            elif isinstance(filters['type'], set):
                 assertion_set = filters['type']
             else:
                 raise AssertionError("Wrong filter type %s" % filters['type'])

--- a/ebi/ols/api/base.py
+++ b/ebi/ols/api/base.py
@@ -111,8 +111,15 @@ class BaseClient:
         """ Filters queries for search"""
         logger.debug('Applying filters %s', filters)
         assert set(filters.keys()).issubset(
-            {'exact', 'fieldList', 'groupField', 'obsoletes', 'ontology', 'queryFields', 'slim', 'type', 'local'}), \
+            {'exact', 'fieldList', 'groupField', 'obsoletes', 'ontology', 'queryFields', 'slim', 'type', 'local', 'childrenOf'}), \
             "Unauthorized filter key"
+        if 'childrenOf' in filters:
+            if type(filters['childrenOf']) is str:
+                assertion_set = set(filters['childrenOf'].split(','))
+            elif type(filters['childrenOf']) is set:
+                assertion_set = filters['childrenOf']
+            else:
+                raise AssertionError("Wrong filter childrenOf %s" % filters['childrenOf'])
         if 'fieldList' in filters:
             if type(filters['fieldList']) is str:
                 assertion_set = set(filters['fieldList'].split(','))

--- a/ebi/ols/api/base.py
+++ b/ebi/ols/api/base.py
@@ -123,7 +123,7 @@ class BaseClient:
         if 'fieldList' in filters:
             if type(filters['fieldList']) is str:
                 assertion_set = set(filters['fieldList'].split(','))
-            elif type(filters['fieldList'] is set):
+            elif type(filters['fieldList']) is set:
                 assertion_set = filters['fieldList']
             else:
                 raise AssertionError("Wrong filter FieldList %s" % filters['fieldList'])
@@ -134,7 +134,7 @@ class BaseClient:
         if 'queryFields' in filters:
             if type(filters['queryFields']) is str:
                 assertion_set = set(filters['queryFields'].split(','))
-            elif type(filters['queryFields'] is set):
+            elif type(filters['queryFields']) is set:
                 assertion_set = filters['queryFields']
             else:
                 raise AssertionError("Wrong filter queryFields %s" % filters['queryFields'])
@@ -144,7 +144,7 @@ class BaseClient:
         if 'type' in filters:
             if type(filters['type']) is str:
                 assertion_set = set(filters['type'].split(','))
-            elif type(filters['type'] is set):
+            elif type(filters['type']) is set:
                 assertion_set = filters['type']
             else:
                 raise AssertionError("Wrong filter type %s" % filters['type'])

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -268,6 +268,7 @@ class OntologyTestBasic(unittest.TestCase):
             ontology=ontology,
             filters=filters)
         actual_iris = { term.iri for term in actual_terms }
+        # Then
         expected_iris = {
                 'http://purl.obolibrary.org/obo/PHI_1000003',
                 'http://purl.obolibrary.org/obo/PHI_1000002'
@@ -291,6 +292,7 @@ class OntologyTestBasic(unittest.TestCase):
             ontology=ontology,
             filters=filters)
         actual_iris = { term.iri for term in actual_terms }
+        # Then
         expected_iris = {
                 'http://purl.obolibrary.org/obo/PHI_1000003',
                 'http://purl.obolibrary.org/obo/PHI_1000002',
@@ -312,6 +314,7 @@ class OntologyTestBasic(unittest.TestCase):
             ontology=ontology,
             filters=filters)
         actual_iris = { term.iri for term in actual_terms }
+        # Then
         expected_iris = set()
         self.assertEqual(actual_iris, expected_iris)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -254,6 +254,67 @@ class OntologyTestBasic(unittest.TestCase):
         with self.assertRaises(AssertionError) as ex:
             self.client.search.filters_response(filters)
 
+    def test_single_childrenOf_filters_search_results(self):
+        # Given
+        query = 'chemical'
+        ontology = 'phi'
+        filters = {
+            'fieldList': {'iri'},
+            'childrenOf': 'http://purl.obolibrary.org/obo/PHI_1000000'
+            }
+        # When
+        actual_terms = self.client.search(
+            query=query, 
+            ontology=ontology,
+            filters=filters)
+        actual_iris = { term.iri for term in actual_terms }
+        expected_iris = {
+                'http://purl.obolibrary.org/obo/PHI_1000003',
+                'http://purl.obolibrary.org/obo/PHI_1000002'
+        }
+        assert(actual_iris == expected_iris)
+    
+    def test_multiple_childrenOf_filters_search_results(self):
+        # Given
+        query = 'chemical'
+        ontology = 'phi'
+        filters = {
+            'fieldList': {'iri'},
+            'childrenOf': {
+                'http://purl.obolibrary.org/obo/PHI_1000000',
+                'http://purl.obolibrary.org/obo/PHI_2000000'
+            }
+        }
+        # When
+        actual_terms = self.client.search(
+            query=query, 
+            ontology=ontology,
+            filters=filters)
+        actual_iris = { term.iri for term in actual_terms }
+        expected_iris = {
+                'http://purl.obolibrary.org/obo/PHI_1000003',
+                'http://purl.obolibrary.org/obo/PHI_1000002',
+                'http://purl.obolibrary.org/obo/PHI_2000004'
+        }
+        assert(actual_iris == expected_iris)
+
+    def test_childrenOf_non_existant_parent_yields_no_search_results(self):
+        # Given
+        query = 'chemical'
+        ontology = 'phi'
+        filters = {
+            'fieldList': {'iri'},
+            'childrenOf': 'http://purl.obolibrary.org/obo/PHI_3000000',
+        }
+        # When
+        actual_terms = self.client.search(
+            query=query, 
+            ontology=ontology,
+            filters=filters)
+        actual_iris = { term.iri for term in actual_terms }
+        expected_iris = set()
+        assert(actual_iris == expected_iris)
+
     def test_search_kwargs(self):
         """
         Test Search feature : - kwargs passed

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -272,7 +272,7 @@ class OntologyTestBasic(unittest.TestCase):
                 'http://purl.obolibrary.org/obo/PHI_1000003',
                 'http://purl.obolibrary.org/obo/PHI_1000002'
         }
-        assert(actual_iris == expected_iris)
+        self.assertEqual(actual_iris, expected_iris)
     
     def test_multiple_childrenOf_filters_search_results(self):
         # Given
@@ -296,7 +296,7 @@ class OntologyTestBasic(unittest.TestCase):
                 'http://purl.obolibrary.org/obo/PHI_1000002',
                 'http://purl.obolibrary.org/obo/PHI_2000004'
         }
-        assert(actual_iris == expected_iris)
+        self.assertEqual(actual_iris, expected_iris)
 
     def test_childrenOf_non_existant_parent_yields_no_search_results(self):
         # Given
@@ -313,7 +313,7 @@ class OntologyTestBasic(unittest.TestCase):
             filters=filters)
         actual_iris = { term.iri for term in actual_terms }
         expected_iris = set()
-        assert(actual_iris == expected_iris)
+        self.assertEqual(actual_iris, expected_iris)
 
     def test_search_kwargs(self):
         """

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -229,6 +229,31 @@ class OntologyTestBasic(unittest.TestCase):
             detailed = self.client.detail(prop)
             self._checkMixed(detailed)
 
+    def test_childrenOf_is_valid_response_filter(self):
+        # Given
+        filters = {'childrenOf':'A'}
+        expected_filters = filters.copy()
+        # When
+        actual_filters = self.client.search.filters_response(filters)
+        # Then
+        self.assertEqual(actual_filters, filters)
+
+    def test_childrenOf_value_can_be_set(self):
+        # Given
+        filters = {'childrenOf':{'A','B'}}
+        expected_filters = filters.copy()
+        # When 
+        actual_filters = self.client.search.filters_response(filters)
+        # Then
+        self.assertEqual(actual_filters, filters)
+
+    def test_childrenOf_value_cannot_be_list(self):
+        # Given
+        filters = {'childrenOf': ['A', 'B']}
+        # When /Then
+        with self.assertRaises(AssertionError) as ex:
+            self.client.search.filters_response(filters)
+
     def test_search_kwargs(self):
         """
         Test Search feature : - kwargs passed


### PR DESCRIPTION
* Allow the 'childrenOf' filter in the allowed set of filters
* Add appropriate type checking for this filter
* Add tests for search result filtering behaviour
* Fix some type assertions in the original results filter lists.