### PR TITLE
Relax version requirement by allowing higher package versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-inflection>=0.3.1
-coreapi>=2.3.3
-hal_codec>=1.0.2
-requests>=2.22.0
+inflection~=0.3.1
+coreapi~=2.3.3
+hal_codec~=1.0.2
+requests~=2.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-inflection==0.3.1
-coreapi==2.3.3
-hal_codec==1.0.2
-requests==2.22.0
+inflection>=0.3.1
+coreapi>=2.3.3
+hal_codec>=1.0.2
+requests>=2.22.0


### PR DESCRIPTION
Relaxing these package version requirements allows for better interoperability with other packages. 

I found no adverse effects of having the latest versions of these packages installed with a PY3.10 conda environment.
Note however that the latest version of nosetests, which is used in this project, is currently broken under PY3.10 (and seemingly no longer maintained), but pytest could be used as a drop in replacement.
