### PR TITLE
use ols4 and new docker repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/ols-docker"]
 	path = tests/ols-docker
 	url = https://github.com/Ensembl/OLS-docker.git
-	branch = master
+	branch = main

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -484,7 +484,7 @@ class OntologyTestBasic(unittest.TestCase):
                 BfoClientMixin.count_call = BfoClientMixin.count_call + 1
                 return super().fetch_document(path, params, filters, base_document)
 
-        terms_list_client = BfoClientMixin('/'.join(['https://www.ebi.ac.uk/ols/api', 'ontologies', 'pr']),
+        terms_list_client = BfoClientMixin('/'.join(['https://www.ebi.ac.uk/ols4/api', 'ontologies', 'pr']),
                                            helpers.Term,
                                            page_size=100)
         terms = terms_list_client()


### PR DESCRIPTION
Docker image couldn't be retrieved since we moved to `main` scheme instead of `master`. 
Moved to ols4 api. 